### PR TITLE
Support rendering areas by name suffix

### DIFF
--- a/src/whitehole/rendering/RendererFactory.java
+++ b/src/whitehole/rendering/RendererFactory.java
@@ -99,8 +99,10 @@ public final class RendererFactory {
                 
                 for (int i = 0; i < AREA_SHAPE_NAMES_SUFFIXES.length; i++)
                 {
-                    if (lowerObjName.endsWith(AREA_SHAPE_NAMES_SUFFIXES[i]))
+                    if (lowerObjName.endsWith(AREA_SHAPE_NAMES_SUFFIXES[i])) {
                         areaShapeNo = i;
+                        break;
+                    }
                 }
             }
             


### PR DESCRIPTION
By default, areas in SMG1 relly entirely on their Object Database entries to determine their Area Shape ID. This PR adds support for rendering areas without an ObjectDB entry based on the area's name suffix.

- `Cube` creates a bottom-aligned box. 
- `Box` creates a center-aligned box. 
- `Sphere` creates a sphere.
- `Cylinder` creates a cylinder.
- `Bowl` creates a bowl.

These suffixes come from the base game's area naming scheme.