### PR TITLE
Fix Linux crash in JOGL native loading when opening a galaxy

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -4,11 +4,6 @@
     <import file="nbproject/build-impl.xml"/>
     <target name="-post-jar">
         <copy file="Whitehole.bat" todir="${dist.dir}"/>
-        <!-- Unpack the Linux JOGL natives next to the jar. On Linux, Whitehole points
-             jogamp.primary.library.path here and disables GlueGen's temp-jar cache so the
-             natives are loaded from this fixed directory. That avoids GlueGen's temp-dir
-             executability self-test (a fork+exec) racing with JOGL's own dlopen and
-             crashing in glibc's dynamic linker when a galaxy is opened. -->
         <unzip src="lib/jogamp-fat.jar" dest="${dist.dir}">
             <patternset>
                 <include name="natives/linux-*/**"/>

--- a/build.xml
+++ b/build.xml
@@ -4,6 +4,16 @@
     <import file="nbproject/build-impl.xml"/>
     <target name="-post-jar">
         <copy file="Whitehole.bat" todir="${dist.dir}"/>
+        <!-- Unpack the Linux JOGL natives next to the jar. On Linux, Whitehole points
+             jogamp.primary.library.path here and disables GlueGen's temp-jar cache so the
+             natives are loaded from this fixed directory. That avoids GlueGen's temp-dir
+             executability self-test (a fork+exec) racing with JOGL's own dlopen and
+             crashing in glibc's dynamic linker when a galaxy is opened. -->
+        <unzip src="lib/jogamp-fat.jar" dest="${dist.dir}">
+            <patternset>
+                <include name="natives/linux-*/**"/>
+            </patternset>
+        </unzip>
         <copy file="data/hashlookup.txt" todir="${dist.dir}/data"/>
         <copy file="data/galaxies.json" todir="${dist.dir}/data"/>
         <copy file="data/zones.json" todir="${dist.dir}/data"/>

--- a/src/whitehole/Whitehole.java
+++ b/src/whitehole/Whitehole.java
@@ -53,6 +53,7 @@ public class Whitehole {
     public static final GameAndProjectDataHolder Shortcuts = new GameAndProjectDataHolder("data/shortcuts.json", "/shortcuts.json", true);
     
     public static void main(String[] args) throws IOException {
+        configureJoglNativeLoading();
         decideIconSize();
         // Setup look and feel and set if applicable
         FlatDarkLaf.setup();
@@ -100,6 +101,44 @@ public class Whitehole {
         MAIN_FRAME.setVisible(true);
     }
     
+    /**
+     * On Linux, tell JOGL to load its native libraries from the {@code natives/<arch>}
+     * directory shipped next to the jar instead of unpacking them to a temporary
+     * directory. Before loading from a temp directory GlueGen fork+execs a small shell
+     * script to verify the directory is executable, and on Linux that subprocess launch
+     * races with JOGL's own dlopen inside glibc's dynamic linker, crashing the JVM
+     * (SIGSEGV in ld-linux) the first time a galaxy is opened. Loading from a fixed
+     * directory with the temp-jar cache disabled avoids the self-test entirely.
+     *
+     * Only applied when the natives directory is present (i.e. a built distribution), so
+     * running from an IDE or on other platforms keeps JOGL's default behaviour.
+     */
+    private static void configureJoglNativeLoading() {
+        if (!System.getProperty("os.name", "").toLowerCase().contains("linux"))
+            return;
+
+        String nativeDir;
+        switch (System.getProperty("os.arch", "")) {
+            case "amd64": case "x86_64": nativeDir = "linux-amd64"; break;
+            case "aarch64": case "arm64": nativeDir = "linux-aarch64"; break;
+            case "arm": case "armv6l": case "armv7l": nativeDir = "linux-armv6hf"; break;
+            default: return;
+        }
+
+        try {
+            File jar = new File(Whitehole.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+            File natives = new File(jar.getParentFile(), "natives/" + nativeDir);
+
+            if (natives.isDirectory() && System.getProperty("jogamp.primary.library.path") == null) {
+                System.setProperty("jogamp.gluegen.UseTempJarCache", "false");
+                System.setProperty("jogamp.primary.library.path", natives.getAbsolutePath());
+            }
+        }
+        catch (Exception ex) {
+            System.err.println("Could not configure JOGL native loading: " + ex);
+        }
+    }
+
     public static void requestUpdateLAF() {
         LookAndFeel next = null;
         

--- a/src/whitehole/Whitehole.java
+++ b/src/whitehole/Whitehole.java
@@ -101,18 +101,6 @@ public class Whitehole {
         MAIN_FRAME.setVisible(true);
     }
     
-    /**
-     * On Linux, tell JOGL to load its native libraries from the {@code natives/<arch>}
-     * directory shipped next to the jar instead of unpacking them to a temporary
-     * directory. Before loading from a temp directory GlueGen fork+execs a small shell
-     * script to verify the directory is executable, and on Linux that subprocess launch
-     * races with JOGL's own dlopen inside glibc's dynamic linker, crashing the JVM
-     * (SIGSEGV in ld-linux) the first time a galaxy is opened. Loading from a fixed
-     * directory with the temp-jar cache disabled avoids the self-test entirely.
-     *
-     * Only applied when the natives directory is present (i.e. a built distribution), so
-     * running from an IDE or on other platforms keeps JOGL's default behaviour.
-     */
     private static void configureJoglNativeLoading() {
         if (!System.getProperty("os.name", "").toLowerCase().contains("linux"))
             return;


### PR DESCRIPTION
On Linux, opening a galaxy can crash the JVM with SIGSEGV inside glibc's
dynamic linker — specifically `strcmp` in `_dl_map_object` (the dlopen
"already loaded?" scan), not in Whitehole/JOGL Java code.

**Root cause:** On a cold cache, GlueGen unpacks its natives to a temp dir
and, before loading them, fork+execs a small shell script to verify the dir is
executable. When that subprocess runs concurrently with the load of
`libgluegen_rt.so`, that library ends up in the loader's object list with its
dynamic section left unrelocated — `DT_STRTAB`/`DT_SONAME` still hold file
offsets (here `0x8c8`/`0x8e5`) while the link_map is treated as relocated. Its
computed soname is then a wild pointer (`0x8c8 + 0x8e5 = 0x11ad`), so the next
`dlopen` that scans sonames dereferences it and crashes. Reproduces only on a
cold temp cache (when the exec test runs) and is independent of the JOGL
version.

**Fix:** load the natives from a fixed directory instead of a temp one.
`build.xml` unpacks the Linux natives to `natives/<arch>`, and `Whitehole`
sets `jogamp.primary.library.path` there with `UseTempJarCache=false` (both via
`System.setProperty`, so `java -jar` works unchanged). No temp dir and no
exec-test subprocess are used; the natives still load and GL works normally.
Linux-only (guarded by `os.name`/`os.arch` and the presence of the natives
directory); Windows and macOS keep JOGL's default behaviour.

Verified on Ubuntu 24.04 (glibc 2.39) / OpenJDK 21 / GNOME Wayland: crashes
before, opens galaxies fine after.
